### PR TITLE
Updater: add changelog dialog & show if an update is new or old

### DIFF
--- a/res/menu/menu_toolbar.xml
+++ b/res/menu/menu_toolbar.xml
@@ -10,8 +10,4 @@
         android:id="@+id/menu_preferences"
         android:title="@string/menu_preferences"
         app:showAsAction="never" />
-    <item
-        android:id="@+id/menu_show_changelog"
-        android:title="@string/menu_show_changelog"
-        app:showAsAction="never" />
 </menu>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -130,8 +130,7 @@
     <string name="menu_mobile_data_warning">Mobile data warning</string>
 
     <string name="blocked_update_dialog_title">Update blocked</string>
-    <string name="blocked_update_dialog_message">This update cannot be installed using the updater app.  Please read <xliff:g id="info_url">%1$s</xliff:g> for more information.</string>
-    <string name="blocked_update_info_url" translatable="false">http://wiki.lineageos.org/upgrading.html</string>
+    <string name="blocked_update_dialog_message">This update cannot be installed using the updater app.</string>
 
     <string name="export_channel_title">Export completion</string>
     <string name="new_updates_channel_title">New updates</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -63,8 +63,6 @@
     <string name="menu_delete_update">Delete</string>
     <string name="menu_copy_url">Copy URL</string>
     <string name="menu_export_update">Export update</string>
-    <string name="menu_show_changelog">Show changelog</string>
-    <string name="menu_changelog_url" translatable="false">https://bootleggersrom-devices.github.io/changelog/<xliff:g id="device_name">%1$s</xliff:g></string>
     <string name="menu_ab_perf_mode">Prioritize update process</string>
 
     <string name="snack_updates_found">New updates found</string>
@@ -151,4 +149,8 @@
     <string name="update_new_release">A new update came for your %s!</string>
     <string name="update_new_release_small">Check the new improvements and changes that this build brings or download it right now.</string>
     <string name="update_new_release_big">Check the new stuff that\'s waiting for you or download this new release right now.</string>
+
+    <!-- changelog -->
+    <string name="changelog_url" translatable="false">https://raw.githubusercontent.com/BootleggersROM-Devices/BootleggersROM-Devices.github.io/master/_changelog/<xliff:g id="device_name">%1$s</xliff:g>.md</string>
+    <string name="changelog_fail">Failed to retrieve changelog</string>
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -149,7 +149,7 @@
     <string name="update_new_release_small">Check the new improvements and changes that this build brings or download it right now.</string>
     <string name="update_new_release_big">Check the new stuff that\'s waiting for you or download this new release right now.</string>
     <string name="update_old_title">Old update</string>
-    <string name="update_old_summary">Now that the installation completed successfully, you can get the zip from /data/shishu_updates or delete it.</string>
+    <string name="update_old_summary">Now that the installation completed successfully, you can long click to export the update, or delete it.</string>
 
     <!-- changelog -->
     <string name="changelog_url" translatable="false">https://raw.githubusercontent.com/BootleggersROM-Devices/BootleggersROM-Devices.github.io/master/_changelog/<xliff:g id="device_name">%1$s</xliff:g>.md</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -148,6 +148,8 @@
     <string name="update_new_release">A new update came for your %s!</string>
     <string name="update_new_release_small">Check the new improvements and changes that this build brings or download it right now.</string>
     <string name="update_new_release_big">Check the new stuff that\'s waiting for you or download this new release right now.</string>
+    <string name="update_old_title">Old update</string>
+    <string name="update_old_summary">Now that the installation completed successfully, you can get the zip from /data/shishu_updates or delete it.</string>
 
     <!-- changelog -->
     <string name="changelog_url" translatable="false">https://raw.githubusercontent.com/BootleggersROM-Devices/BootleggersROM-Devices.github.io/master/_changelog/<xliff:g id="device_name">%1$s</xliff:g>.md</string>

--- a/res/values/styles.xml
+++ b/res/values/styles.xml
@@ -23,7 +23,7 @@
     </style>
 
     <style name="TextAppearanceInverted" parent="TextAppearance.AppCompat.Widget.ActionBar.Title">
-        <item name="android:textColor">@color/inverted</item>
+        <item name="android:textColor">@color/theme_accent</item>
     </style>
     <style name="TextAppearanceTransparent" parent="TextAppearance.AppCompat.Widget.ActionBar.Title">
         <item name="android:textColor">@android:color/transparent</item>

--- a/src/com/bootleggers/shishuota/UpdatesActivity.java
+++ b/src/com/bootleggers/shishuota/UpdatesActivity.java
@@ -193,12 +193,6 @@ public class UpdatesActivity extends UpdatesListActivity {
                 showPreferencesDialog();
                 return true;
             }
-            case R.id.menu_show_changelog: {
-                Intent openUrl = new Intent(Intent.ACTION_VIEW,
-                        Uri.parse(Utils.getChangelogURL(this)));
-                startActivity(openUrl);
-                return true;
-            }
         }
         return super.onOptionsItemSelected(item);
     }

--- a/src/com/bootleggers/shishuota/UpdatesActivity.java
+++ b/src/com/bootleggers/shishuota/UpdatesActivity.java
@@ -227,12 +227,16 @@ public class UpdatesActivity extends UpdatesListActivity {
         Log.d(TAG, "Adding remote updates");
         UpdaterController controller = mUpdaterService.getUpdaterController();
         boolean newUpdates = false;
+        boolean isNew = false;
 
         List<UpdateInfo> updates = Utils.parseJson(jsonFile, true);
         List<String> updatesOnline = new ArrayList<>();
         for (UpdateInfo update : updates) {
             newUpdates |= controller.addUpdate(update);
             updatesOnline.add(update.getDownloadId());
+            if (Utils.canInstall(update)) {
+                isNew = true;
+            }
         }
         controller.setUpdatesAvailableOnline(updatesOnline, true);
 
@@ -257,8 +261,13 @@ public class UpdatesActivity extends UpdatesListActivity {
                 updateIds.add(update.getDownloadId());
                 ((TextView) findViewById(R.id.header_update_release_date)).setText("(" + Utils.getParsedDate(update.getBuildDate(), false) + ")");
             }
-            ((TextView) findViewById(R.id.header_update_status)).setText(R.string.header_updates_new_build);
-            findViewById(R.id.header_update_release_date).setVisibility(View.VISIBLE);
+            if (isNew) {
+                ((TextView) findViewById(R.id.header_update_status)).setText(R.string.header_updates_new_build);
+                findViewById(R.id.header_update_release_date).setVisibility(View.VISIBLE);
+            } else {
+                ((TextView) findViewById(R.id.header_update_status)).setText(R.string.header_updates_no_update);
+                findViewById(R.id.header_update_release_date).setVisibility(View.GONE);
+            }
             /* Example till this is working */
             mAdapter.setData(updateIds);
             mAdapter.notifyDataSetChanged();

--- a/src/com/bootleggers/shishuota/UpdatesListAdapter.java
+++ b/src/com/bootleggers/shishuota/UpdatesListAdapter.java
@@ -20,6 +20,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.content.res.Resources;
+import android.os.AsyncTask;
 import android.os.BatteryManager;
 import android.os.PowerManager;
 import android.os.SystemProperties;
@@ -56,8 +57,11 @@ import com.bootleggers.shishuota.misc.Utils;
 import com.bootleggers.shishuota.model.UpdateInfo;
 import com.bootleggers.shishuota.model.UpdateStatus;
 
+import java.io.BufferedReader;
 import java.io.File;
+import java.io.InputStreamReader;
 import java.io.IOException;
+import java.net.URL;
 import java.text.DateFormat;
 import java.text.NumberFormat;
 import java.util.List;
@@ -82,10 +86,12 @@ public class UpdatesListAdapter extends RecyclerView.Adapter<UpdatesListAdapter.
         DELETE,
         CANCEL_INSTALLATION,
         REBOOT,
+        CHANGELOG,
     }
 
     public static class ViewHolder extends RecyclerView.ViewHolder {
         private Button mAction;
+        private Button mChangelog;
 
         private TextView mBuildDate;
         private TextView mBuildVersion;
@@ -98,6 +104,7 @@ public class UpdatesListAdapter extends RecyclerView.Adapter<UpdatesListAdapter.
         public ViewHolder(final View view) {
             super(view);
             mAction = (Button) view.findViewById(R.id.update_action);
+            mChangelog = (Button) view.findViewById(R.id.update_changelog);
 
             mBuildDate = (TextView) view.findViewById(R.id.build_date);
             mBuildVersion = (TextView) view.findViewById(R.id.build_version);
@@ -189,6 +196,9 @@ public class UpdatesListAdapter extends RecyclerView.Adapter<UpdatesListAdapter.
         viewHolder.mBuildSize.setVisibility(View.INVISIBLE);
         viewHolder.mBuildVersion.setVisibility(View.GONE);
         viewHolder.mBuildSummary.setVisibility(View.GONE);
+
+        // changelog button
+        setButtonAction(viewHolder.mChangelog, Action.CHANGELOG, downloadId, true);
     }
 
     private void handleNotActiveStatus(ViewHolder viewHolder, UpdateInfo update) {
@@ -229,6 +239,9 @@ public class UpdatesListAdapter extends RecyclerView.Adapter<UpdatesListAdapter.
         } else {
             viewHolder.mBuildVersion.setVisibility(View.GONE)
         }**/
+
+        // changelog button
+        setButtonAction(viewHolder.mChangelog, Action.CHANGELOG, downloadId, true);
     }
 
     @Override
@@ -408,6 +421,10 @@ public class UpdatesListAdapter extends RecyclerView.Adapter<UpdatesListAdapter.
                 } : null;
             }
             break;
+            case CHANGELOG: {
+                clickListener = enabled ? view -> new getChangelogDialog().execute(Utils.getChangelogURL(view.getContext())) : null;
+            }
+            break;
             default:
                 clickListener = null;
         }
@@ -562,6 +579,46 @@ public class UpdatesListAdapter extends RecyclerView.Adapter<UpdatesListAdapter.
                 .show();
         TextView textView = (TextView) dialog.findViewById(android.R.id.message);
         textView.setMovementMethod(LinkMovementMethod.getInstance());
+    }
+
+    private class getChangelogDialog extends AsyncTask<String, Void, String> {
+
+        protected String doInBackground(String... strings) {
+            String outputString = "";
+            String inputString;
+            int i = 0;
+
+            try {
+                URL changelog = new URL(strings[0]);
+                BufferedReader in = new BufferedReader(
+                        new InputStreamReader(
+                        changelog.openStream()));
+
+                while((inputString = in.readLine()) != null) {
+                    // don't include the top 4 lines of the changelog
+                    if (i >= 4) {
+                        outputString += inputString + "\n";
+                    }
+                    i++;
+                }
+
+                in.close();
+                return outputString;
+            } catch(IOException e) {
+                Log.e(TAG, "Could not fetch changelog from " + strings[0]);
+                return mActivity.getResources().getString(R.string.changelog_fail);
+            }
+        }
+
+        protected void onPostExecute(String result) {
+            AlertDialog dialog = new AlertDialog.Builder(mActivity)
+                    .setTitle(R.string.update_button_changelog)
+                    .setPositiveButton(android.R.string.ok, null)
+                    .setMessage(result)
+                    .show();
+            TextView textView = (TextView) dialog.findViewById(android.R.id.message);
+            textView.setMovementMethod(LinkMovementMethod.getInstance());
+        }
     }
 
     private boolean isBatteryLevelOk() {

--- a/src/com/bootleggers/shishuota/UpdatesListAdapter.java
+++ b/src/com/bootleggers/shishuota/UpdatesListAdapter.java
@@ -101,6 +101,8 @@ public class UpdatesListAdapter extends RecyclerView.Adapter<UpdatesListAdapter.
         private ProgressBar mProgressBar;
         private TextView mProgressText;
 
+        private TextView mUpdateTitle;
+
         public ViewHolder(final View view) {
             super(view);
             mAction = (Button) view.findViewById(R.id.update_action);
@@ -113,6 +115,8 @@ public class UpdatesListAdapter extends RecyclerView.Adapter<UpdatesListAdapter.
 
             mProgressBar = (ProgressBar) view.findViewById(R.id.progress_bar);
             mProgressText = (TextView) view.findViewById(R.id.progress_text);
+
+            mUpdateTitle = (TextView) view.findViewById(R.id.update_card_title);
         }
     }
 
@@ -203,6 +207,7 @@ public class UpdatesListAdapter extends RecyclerView.Adapter<UpdatesListAdapter.
 
     private void handleNotActiveStatus(ViewHolder viewHolder, UpdateInfo update) {
         final String downloadId = update.getDownloadId();
+        boolean isOld = false;
         if (mUpdaterController.isWaitingForReboot(downloadId)) {
             viewHolder.itemView.setOnLongClickListener(
                     getLongClickListener(update, false, viewHolder.mBuildDate));
@@ -213,6 +218,7 @@ public class UpdatesListAdapter extends RecyclerView.Adapter<UpdatesListAdapter.
             setButtonAction(viewHolder.mAction,
                     Utils.canInstall(update) ? Action.INSTALL : Action.DELETE,
                     downloadId, !isBusy());
+            isOld = true;
         } else if (!Utils.canInstall(update)) {
             viewHolder.itemView.setOnLongClickListener(
                     getLongClickListener(update, false, viewHolder.mBuildDate));
@@ -233,6 +239,12 @@ public class UpdatesListAdapter extends RecyclerView.Adapter<UpdatesListAdapter.
                         R.string.update_summary, mActivity.getString(
                         R.string.update_new_release, SystemProperties.get(Constants.PROP_DEVICE)), mActivity.getString(
                         R.string.update_new_release_small)));
+        if (isOld) {
+            viewHolder.mUpdateTitle.setText(R.string.update_old_title);
+            viewHolder.mBuildSummary.setText(R.string.update_old_summary);
+            viewHolder.mChangelog.setVisibility(View.GONE);
+        }
+
         /**if (Utils.isBigRelease()) {
             viewHolder.mBuildVersion.setVisibility(View.VISIBLE);
             viewHolder.mBuildVersion.setText(Utils.getReleaseVersion(update.getName()));

--- a/src/com/bootleggers/shishuota/UpdatesListAdapter.java
+++ b/src/com/bootleggers/shishuota/UpdatesListAdapter.java
@@ -567,15 +567,10 @@ public class UpdatesListAdapter extends RecyclerView.Adapter<UpdatesListAdapter.
     }
 
     private void showInfoDialog() {
-        String messageString = String.format(StringGenerator.getCurrentLocale(mActivity),
-                mActivity.getString(R.string.blocked_update_dialog_message),
-                mActivity.getString(R.string.blocked_update_info_url));
-        SpannableString message = new SpannableString(messageString);
-        Linkify.addLinks(message, Linkify.WEB_URLS);
         AlertDialog dialog = new AlertDialog.Builder(mActivity)
                 .setTitle(R.string.blocked_update_dialog_title)
                 .setPositiveButton(android.R.string.ok, null)
-                .setMessage(message)
+                .setMessage(R.string.blocked_update_dialog_message)
                 .show();
         TextView textView = (TextView) dialog.findViewById(android.R.id.message);
         textView.setMovementMethod(LinkMovementMethod.getInstance());

--- a/src/com/bootleggers/shishuota/UpdatesListAdapter.java
+++ b/src/com/bootleggers/shishuota/UpdatesListAdapter.java
@@ -218,7 +218,9 @@ public class UpdatesListAdapter extends RecyclerView.Adapter<UpdatesListAdapter.
             setButtonAction(viewHolder.mAction,
                     Utils.canInstall(update) ? Action.INSTALL : Action.DELETE,
                     downloadId, !isBusy());
-            isOld = true;
+            if (!Utils.canInstall(update)) {
+                isOld = true;
+            }
         } else if (!Utils.canInstall(update)) {
             viewHolder.itemView.setOnLongClickListener(
                     getLongClickListener(update, false, viewHolder.mBuildDate));

--- a/src/com/bootleggers/shishuota/misc/Constants.java
+++ b/src/com/bootleggers/shishuota/misc/Constants.java
@@ -40,8 +40,7 @@ public final class Constants {
     public static final String PROP_DEVICE = "ro.bootleggers.device";
     public static final String PROP_NEXT_DEVICE = "ro.updater.next_device";
     public static final String PROP_RELEASE_TYPE = "ro.bootleggers.releasetype";
-    public static final String PROP_UPDATER_ALLOW_DOWNGRADING = "lineage.updater.allow_downgrading";
-    public static final String PROP_UPDATER_URI = "lineage.updater.uri";
+    public static final String PROP_UPDATER_ALLOW_DOWNGRADING = "bootleggers.updater.allow_downgrading";
 
     public static final String PREF_INSTALL_OLD_TIMESTAMP = "install_old_timestamp";
     public static final String PREF_INSTALL_NEW_TIMESTAMP = "install_new_timestamp";

--- a/src/com/bootleggers/shishuota/misc/Utils.java
+++ b/src/com/bootleggers/shishuota/misc/Utils.java
@@ -171,7 +171,7 @@ public class Utils {
     public static String getChangelogURL(Context context) {
         String device = SystemProperties.get(Constants.PROP_NEXT_DEVICE,
                 SystemProperties.get(Constants.PROP_DEVICE));
-        return context.getString(R.string.menu_changelog_url, device);
+        return context.getString(R.string.changelog_url, device);
     }
 
     public static void triggerUpdate(Context context, String downloadId) {

--- a/src/com/bootleggers/shishuota/misc/Utils.java
+++ b/src/com/bootleggers/shishuota/misc/Utils.java
@@ -154,20 +154,6 @@ public class Utils {
         return updates;
     }
 
-    public static String getServerURL(Context context) {
-        String incrementalVersion = SystemProperties.get(Constants.PROP_BUILD_VERSION_INCREMENTAL);
-        String device = SystemProperties.get(Constants.PROP_NEXT_DEVICE,
-                SystemProperties.get(Constants.PROP_DEVICE));
-        String type = SystemProperties.get(Constants.PROP_RELEASE_TYPE).toLowerCase(Locale.ROOT);
-
-        String serverUrl = SystemProperties.get(Constants.PROP_UPDATER_URI);
-        if (serverUrl.trim().isEmpty()) {
-            serverUrl = context.getString(R.string.updater_server_url);
-        }
-
-        return serverUrl;
-    }
-
     public static String getChangelogURL(Context context) {
         String device = SystemProperties.get(Constants.PROP_NEXT_DEVICE,
                 SystemProperties.get(Constants.PROP_DEVICE));


### PR DESCRIPTION
Signed-off-by: shagbag913 <sh4gbag913@gmail.com>

At the moment, the update card shows there is a new update even if the update is actually an old update. This fixes that. Also, add a change of dialog which fetches the content from the raw github changelog file.